### PR TITLE
bugfix: divide by zero error for endpoints with no custom types

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -53,12 +53,13 @@ def lambda_handler(event: dict, context: dict) -> dict:
   boto3.resource('dynamodb')
   deserializer = boto3.dynamodb.types.TypeDeserializer()
 
+  print(event)
   # getItem api call, pass in params
   response = client.get_item(
-    TableName = "UserData",
+    TableName = "GraphQLData",
     Key = {
-      'UserID': {
-          'S': event['UserID']
+      'AccessID': {
+          'S': event['AccessID']
       }
     }
   )

--- a/resolvers.py
+++ b/resolvers.py
@@ -87,7 +87,7 @@ def get_resolvers_data(data: dict) -> dict:
   sum_ave = \
     sum([p_dic['executionTimes'][x] * p_dic['invocationCounts'][x]
          for x in p_dic['invocationCounts']])
-  p_dic['averageTime'] = sum_ave / total_count
+  p_dic['averageTime'] = sum_ave / total_count if total_count > 0 else 0.0
 
   # Return the processed data.
   return p_dic


### PR DESCRIPTION
resolvers.py line 90 ... ternary that checks for zero length resolvers array